### PR TITLE
Resize card images for full view

### DIFF
--- a/home.html
+++ b/home.html
@@ -194,7 +194,7 @@
         left: 0;
         width: 100%;
         height: 100%;
-        object-fit: cover;
+        object-fit: contain;
         z-index: 1;
         filter: brightness(0.85) saturate(1.1);
         transition: var(--lynx-transition);


### PR DESCRIPTION
Display full images on cards by changing `object-fit` to `contain`.