### PR TITLE
Lower importance of notice card on mobile

### DIFF
--- a/food.html
+++ b/food.html
@@ -823,6 +823,9 @@
         .disclaimer-content p {
           font-size: 0.9rem;
         }
+        .disclaimer-section {
+          margin-top: 32px;
+        }
       }
       .restaurants-section .food-service-item {
         background: #f8fff9;


### PR DESCRIPTION
Lower the "Important Notice" card container on `food.html` for mobile by increasing its top margin.